### PR TITLE
Refactor the code safe_html function to escape {{ as well as {\0{

### DIFF
--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -31,7 +31,7 @@ module Temple
       # Used by escape_html
       # @api private
       STRING_HTML_MATCHES = {
-         '&'  => '&amp;',
+        '&'  => '&amp;',
         '"'  => '&quot;',
         '\'' => '&#39;',
         '<'  => '&lt;',
@@ -64,9 +64,14 @@ module Temple
       def escape_html(html)
         html.to_s.gsub(ESCAPE_HTML_PATTERN) do |c|
           string_match = STRING_HTML_MATCHES[c]
-          next string_match if string_match
 
-          REGEXP_HTML_MATCHES.find {|key, _value| c =~ key }&.dig(1)
+          if string_match
+            string_match
+          else
+            match_pair = REGEXP_HTML_MATCHES.find{ |key, _| c =~ key }
+
+            match_pair ? match_pair[1] : nil
+          end
         end
       end
     end

--- a/lib/temple/utils.rb
+++ b/lib/temple/utils.rb
@@ -30,19 +30,24 @@ module Temple
     else
       # Used by escape_html
       # @api private
-      ESCAPE_HTML = {
-        '&'  => '&amp;',
+      STRING_HTML_MATCHES = {
+         '&'  => '&amp;',
         '"'  => '&quot;',
         '\'' => '&#39;',
         '<'  => '&lt;',
         '>'  => '&gt;',
+      }.freeze
+
+      REGEXP_HTML_MATCHES = {
         # In addition to HTML, also escape {{ and }} which are used in Angular
         # templates as expression delimeters.
         # See https://docs.angularjs.org/guide/expression
         # and https://docs.angularjs.org/api/ng/service/$interpolate
-        '{{'  => '\{\{',
-        '}}'  => '\}\}'
+        /\{\x00*\{/ => '\{\{',
+        /\}\x00*\}/ => '\}\}',
       }.freeze
+
+      ESCAPE_HTML = STRING_HTML_MATCHES.merge(REGEXP_HTML_MATCHES).freeze
 
       if //.respond_to?(:encoding)
         ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)
@@ -52,21 +57,16 @@ module Temple
         ESCAPE_HTML_PATTERN = /#{Regexp.union(*ESCAPE_HTML.keys)}/n
       end
 
-      if RUBY_VERSION > '1.9'
-        # Returns an escaped copy of `html`.
-        #
-        # @param html [String] The string to escape
-        # @return [String] The escaped string
-        def escape_html(html)
-          html.to_s.gsub(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
-        end
-      else
-        # Returns an escaped copy of `html`.
-        #
-        # @param html [String] The string to escape
-        # @return [String] The escaped string
-        def escape_html(html)
-          html.to_s.gsub(ESCAPE_HTML_PATTERN) {|c| ESCAPE_HTML[c] }
+      # Returns an escaped copy of `html`.
+      #
+      # @param html [String] The string to escape
+      # @return [String] The escaped string
+      def escape_html(html)
+        html.to_s.gsub(ESCAPE_HTML_PATTERN) do |c|
+          string_match = STRING_HTML_MATCHES[c]
+          next string_match if string_match
+
+          REGEXP_HTML_MATCHES.find {|key, _value| c =~ key }&.dig(1)
         end
       end
     end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -25,6 +25,14 @@ describe Temple::Utils do
     Temple::Utils.escape_html('<').should.equal '&lt;'
   end
 
+  it 'can escape angular templating' do
+    with_html_safe do
+      Temple::Utils.escape_html('{{ 1 + 1 }}').should.equal '\{\{ 1 + 1 \}\}'
+      Temple::Utils.escape_html("{\x00{ 1 + 1 }\x00}").should.equal '\{\{ 1 + 1 \}\}'
+      Temple::Utils.escape_html("{\x00\x00{ 1 + 1 }\x00\x00}").should.equal '\{\{ 1 + 1 \}\}'
+    end
+  end
+
   it 'should escape unsafe html strings' do
     with_html_safe do
       Temple::Utils.escape_html_safe('<').should.equal '&lt;'


### PR DESCRIPTION
Because we need to use regexp matching (`/\{\x00*\{/`) we need to refactor the
way that matched strings are replace in order to find the correct replacement.

