### PR TITLE
Add a set_escape_html_proc fn to temple/utils

### DIFF
--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -27,9 +27,23 @@ describe Temple::Utils do
 
   it 'can escape angular templating' do
     with_html_safe do
+      Temple::Utils.set_escape_html_proc(Temple::Utils.internal_escape_html_proc)
       Temple::Utils.escape_html('{{ 1 + 1 }}').should.equal '\{\{ 1 + 1 \}\}'
       Temple::Utils.escape_html("{\x00{ 1 + 1 }\x00}").should.equal '\{\{ 1 + 1 \}\}'
       Temple::Utils.escape_html("{\x00\x00{ 1 + 1 }\x00\x00}").should.equal '\{\{ 1 + 1 \}\}'
+    end
+  end
+
+  it 'can replace html escaping' do
+    with_html_safe do
+      begin
+        # verify that if we set a custom html escape transform, it actually gets used
+        prev = Temple::Utils.set_escape_html_proc(lambda {|html| "fore #{html} aft" })
+        Temple::Utils.escape_html('{{ 1 + 1 }}').should.equal 'fore {{ 1 + 1 }} aft'
+        Temple::Utils.escape_html('<').should.equal 'fore < aft'
+      ensure
+        Temple::Utils.set_escape_html_proc(prev)
+      end
     end
   end
 


### PR DESCRIPTION
so that apps can override the temple built-in self-select of which escape_html impl will be used.
Temple's self-select favors EscapeUtils & CGI/escape to escape HTML strings, but neither of those escapes Angular / handlebars {{ }} expressions

Temple v0.6.10 didn't include CGI/escape in its self-select choices.  CGI/escape was added to Temple somewhere between v0.6.10 and v0.8.0. Since CGI/escape is available in the Looker build, this causes Slim/Temple to select away from Temple's built-in html_escape implementation, which (now) escapes angular expressions as a protection against injection attacks.